### PR TITLE
chore: Adding Pipeline instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,32 @@ const secret = cdk.SecretValue.secretsManager(secretPath, {
 }).toString();
 console.log(secret); // {{resolve:secretsmanager:SecretName:SecretString:example::md5hashvalue}}
 ```
+
+##### CDK Pipeline - Automatic update of Secrets
+If you are using the cdk module aws-cdk-pipelines you can use the following CodeBuild-Step to automatically update your secret:
+
+```typescript
+
+    const updateSecretEU = new pipelines.CodeBuildStep( 'updateSecret', {
+      commands:[
+        
+        `npx secretsmanager-versioning -f ${secretFileName} '${secretName}'`,
+      ],
+      rolePolicyStatements: [
+        new iam.PolicyStatement({actions:[
+          "secretsmanager:UntagResource",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:PutSecretValue",
+          "secretsmanager:UpdateSecretVersionStage",
+          "secretsmanager:TagResource"
+        ],resources:[secretArn]}),
+        new iam.PolicyStatement({actions:[
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey"
+        ],resources:[secretKeyArn]})
+
+      ]
+    })
+```
+Further define this CodeBuild-Step as a pre-action in your stage.


### PR DESCRIPTION
Added example for automatic updating of an secret with aws-cdk/pipelines pipeline.

Fixes #